### PR TITLE
fix(gitpull): format git pull output for cleaner chat replies

### DIFF
--- a/src/commands/dev/gitpull.js
+++ b/src/commands/dev/gitpull.js
@@ -1,18 +1,53 @@
 const { exec } = require("child_process");
 
+function formatGitPullReply(stdout, stderr) {
+  const output = [stdout, stderr].filter(Boolean).join("\n").trim();
+  if (!output) return "Atualizado 👍";
+  if (/already up to date/i.test(output)) return "Já está atualizado 👍";
+
+  const range = output.match(/Updating ([a-f0-9]+)\.\.([a-f0-9]+)/i);
+  if (range) {
+    const from = range[1].slice(0, 7);
+    const to = range[2].slice(0, 7);
+    const files = output.match(/(\d+) files? changed/i);
+    const insertions = output.match(/(\d+) insertions?\(\+\)/i);
+    const deletions = output.match(/(\d+) deletions?\(-\)/i);
+    const stats = [];
+    if (files) stats.push(`${files[1]} arquivo${files[1] === "1" ? "" : "s"}`);
+    const diff = [
+      insertions ? `+${insertions[1]}` : null,
+      deletions ? `-${deletions[1]}` : null,
+    ]
+      .filter(Boolean)
+      .join(" ");
+    if (diff) stats.push(diff);
+    const statsPart = stats.length ? ` (${stats.join(", ")})` : "";
+    return `Atualizado ${from} → ${to}${statsPart} 👍`;
+  }
+
+  const firstLine =
+    output
+      .split("\n")
+      .find((l) => l.trim())
+      ?.trim() ?? "";
+  if (!firstLine || firstLine.length > 120) return "Atualizado 👍";
+  return `${firstLine} 👍`;
+}
+
 const gitPullCommand = async () => {
   return new Promise((resolve) => {
-    exec("git pull", (error, stdout) => {
+    exec("git pull", { cwd: process.cwd() }, (error, stdout, stderr) => {
       if (error) {
         resolve({
-          reply: `Git pull error: ${error.message}`,
+          reply: "Deu não, check logs",
           notes: `Git pull failed: ${error}`,
         });
         return;
       }
+      const fullOutput = [stdout, stderr].filter(Boolean).join("\n");
       resolve({
-        reply: `Git pull successful: ${stdout}`,
-        notes: `Git pull success: ${stdout}`,
+        reply: formatGitPullReply(stdout, stderr),
+        notes: `Git pull success:\n${fullOutput}`,
       });
     });
   });


### PR DESCRIPTION
## Summary
- Parse `git pull` stdout/stderr into short Portuguese chat replies instead of dumping raw multi-line output
- Fast-forward pulls show commit range, file count, and `+N -M` diff stats (e.g. `Atualizado abc1234 → def5678 (2 arquivos, +12 -2) 👍`)
- "Already up to date" and errors use concise messages aligned with other dev commands; full git output stays in `notes`

## Test plan
- [ ] Run `!gitpull` when repo is already up to date → `Já está atualizado 👍`
- [ ] Run `!gitpull` after pushing new commits to remote → formatted range + stats, no per-file list in chat
- [ ] Confirm full git output still appears in Discord/logs via `notes`
- [ ] Verify failure case shows `Deu não, check logs` with error details in notes


Made with [Cursor](https://cursor.com)